### PR TITLE
Update Kubectl Plugin - v0.0.4

### DIFF
--- a/kubectl-plugin/log2rbac.yaml
+++ b/kubectl-plugin/log2rbac.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: log2rbac
 spec:
-  version: "v0.0.3"
+  version: "v0.0.4"
   homepage: https://github.com/jkremser/log2rbac-operator/tree/master/kubectl-plugin
   shortDescription: "Fine-tune your RBAC using log2rbac operator"
   description: |
@@ -21,9 +21,9 @@ spec:
             values:
               - darwin
               - linux
-      uri: https://github.com/jkremser/log2rbac-operator/archive/refs/tags/v0.0.3.zip
+      uri: https://github.com/jkremser/log2rbac-operator/archive/refs/tags/v0.0.4.zip
       # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
-      sha256: cfb16477eafad55b83c08d96b9df38ca0968ef242208002a130c99b4e326c9e3
+      sha256: a702a8c82bca9d6fa33afaedc47d700a44742dd02f297c53fc40fc2eb5264931
       files:
         - from: "log2rbac-operator-*/kubectl-plugin/kubectl-log2rbac"
           to: "."


### PR DESCRIPTION
:package: Updating kubectl plugin :package:

new yaml manifest for release `v0.0.4`
Make sure the version is correctly set in VERSION file.
This needs to be done before creating the tag for release.

This automated PR was created by [this action][1].

[1]: https://github.com/jkremser/log2rbac-operator/actions/runs/2576943500